### PR TITLE
Fix for countsplit function in utils.R

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -261,17 +261,17 @@ get_GO_matrix = function(
 #'
 #' @export
 countsplit_matrix = function(
-        input,
-        seed = 42
+    input,
+    seed = 42
 ) {
-    set.seed(seed)
-    split = countsplit(input, epsilon=0.5)
-    auc = split$train
-    auc@x = as.numeric(auc@x)
-    de = split$test
-    out_list = list(
-        'run_auc' = auc,
-        'run_de' = de
-    )
-    return(out_list)
+  set.seed(seed)
+  split = countsplit(input, epsilon=0.5)
+  auc = split[[1]]
+  auc@x = as.numeric(auc@x)
+  de = split[[2]]
+  out_list = list(
+    'run_auc' = auc,
+    'run_de' = de
+  )
+  return(out_list)
 }


### PR DESCRIPTION
> vespucci_res = run_vespucci(input = input, meta = meta)

run_vespucci runs the following functions in this particular order: countsplit_matrix, calculate_spatial_auc and find_spatial_de

And the error here propagates from the function: `countsplit_matrix` as mentioned below ...

Splitting matrix
As no overdispersion parameters were provided, Poisson count splitting will be performed. Error in auc@x : 
  no applicable method for `@` applied to an object of class "NULL"